### PR TITLE
Update commons-text to 1.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,14 +122,14 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.11</version>
+            <version>3.12.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-text -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.8</version>
+            <version>1.10.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/commons-text-api-plugin/pull/13#issuecomment-1278814319

It's probably worth to cut a release, to silence security scanners and reduce the amount of Jira issues.

cc @jenkinsci/osf-builder-suite-for-sfcc-deploy-plugin-developers 